### PR TITLE
Use numbers in json for numeric values.

### DIFF
--- a/src/Xiaomi_Scale.py
+++ b/src/Xiaomi_Scale.py
@@ -276,23 +276,23 @@ class ScanProcessor():
 
         lib = Xiaomi_Scale_Body_Metrics.bodyMetrics(calcweight, height, age, sex, 0)
         message = '{'
-        message += '"weight":"' + "{:.2f}".format(weight) + '"'
+        message += '"weight":' + "{:.2f}".format(weight)
         message += ',"weight_unit":"' + str(unit) + '"'
-        message += ',"bmi":"' + "{:.2f}".format(lib.getBMI()) + '"'
-        message += ',"basal_metabolism":"' + "{:.2f}".format(lib.getBMR()) + '"'
-        message += ',"visceral_fat":"' + "{:.2f}".format(lib.getVisceralFat()) + '"'
+        message += ',"bmi":' + "{:.2f}".format(lib.getBMI())
+        message += ',"basal_metabolism":' + "{:.2f}".format(lib.getBMR())
+        message += ',"visceral_fat":' + "{:.2f}".format(lib.getVisceralFat())
 
         if hasImpedance:
             lib = Xiaomi_Scale_Body_Metrics.bodyMetrics(calcweight, height, age, sex, int(miimpedance))
             bodyscale = ['Obese', 'Overweight', 'Thick-set', 'Lack-exerscise', 'Balanced', 'Balanced-muscular', 'Skinny', 'Balanced-skinny', 'Skinny-muscular']
-            message += ',"lean_body_mass":"' + "{:.2f}".format(lib.getLBMCoefficient()) + '"'
-            message += ',"body_fat":"' + "{:.2f}".format(lib.getFatPercentage()) + '"'
-            message += ',"water":"' + "{:.2f}".format(lib.getWaterPercentage()) + '"'
-            message += ',"bone_mass":"' + "{:.2f}".format(lib.getBoneMass()) + '"'
-            message += ',"muscle_mass":"' + "{:.2f}".format(lib.getMuscleMass()) + '"'
-            message += ',"protein":"' + "{:.2f}".format(lib.getProteinPercentage()) + '"'
+            message += ',"lean_body_mass":' + "{:.2f}".format(lib.getLBMCoefficient())
+            message += ',"body_fat":' + "{:.2f}".format(lib.getFatPercentage())
+            message += ',"water":' + "{:.2f}".format(lib.getWaterPercentage())
+            message += ',"bone_mass":' + "{:.2f}".format(lib.getBoneMass())
+            message += ',"muscle_mass":' + "{:.2f}".format(lib.getMuscleMass())
+            message += ',"protein":' + "{:.2f}".format(lib.getProteinPercentage())
             message += ',"body_type":"' + str(bodyscale[lib.getBodyType()]) + '"'
-            message += ',"metabolic_age":"' + "{:.0f}".format(lib.getMetabolicAge()) + '"'
+            message += ',"metabolic_age":' + "{:.0f}".format(lib.getMetabolicAge())
 
         message += ',"timestamp":"' + mitdatetime + '"'
         message += '}'


### PR DESCRIPTION
Using numeric values in json for numbers instead of strings will simplify integration with telegraf/influxdb/grafana stack and generally looks more appropriate.

Number format is also compatible with Home Assistant.