### PR TITLE
Add docker build action for github.

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,27 @@
+name: Docker Build
+
+on:
+  push:
+    branches: master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build image
+        run: |
+          docker buildx build --push \
+            --tag lolouk44/xiaomi-mi-scale:latest \
+            --platform linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64 .


### PR DESCRIPTION
Not sure if it's really needed for you, but want to share what I've done in my fork to simplify build process. So feel free to reject.

This commit enables GitHub Action which will automatically build docker images for the mentioned platforms and push images to docker hub. You just need to specify `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` in your GitHub repo secrets.