### PR TITLE
Support TLS connections to MQTT server

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ services:
     - MQTT_USERNAME=                # Username for MQTT server (comment out if not required)
     - MQTT_PASSWORD=                # Password for MQTT (comment out if not required)
     - MQTT_PORT=                    # Defaults to 1883
+    - MQTT_TLS_CACERTS=             # MQTT TLS connection: directory with CA certificate(s) that signed MQTT Server's TLS certificate, defaults to None (= no TLS connection)
+    - MQTT_TLS_INSECURE=            # MQTT TLS connection: don't verify hostname in TLS certificate, defaults to None (= always check hostname)
     - TIME_INTERVAL=30              # Time in sec between each query to the scale, to allow other applications to use the Bluetooth module. Defaults to 30
     - MQTT_DISCOVERY=true           # Home Assistant Discovery (true/false), defaults to true
     - MQTT_DISCOVERY_PREFIX=        # Home Assistant Discovery Prefix, defaults to homeassistant

--- a/src/Xiaomi_Scale.py
+++ b/src/Xiaomi_Scale.py
@@ -54,6 +54,16 @@ try:
             MQTT_PORT = 1883
             pass
         try:
+            MQTT_TLS_CACERTS = data["MQTT_TLS_CACERTS"]
+        except:
+            MQTT_TLS_CACERTS = None
+            pass
+        try:
+            MQTT_TLS_INSECURE = data["MQTT_TLS_INSECURE"]
+        except:
+            MQTT_TLS_INSECURE = None
+            pass
+        try:
             MQTT_PREFIX = data["MQTT_PREFIX"]
         except:
             MQTT_PREFIX = "miscale"
@@ -159,6 +169,8 @@ except FileNotFoundError:
     MQTT_PASSWORD = os.getenv('MQTT_PASSWORD', None)
     MQTT_HOST = os.getenv('MQTT_HOST', '127.0.0.1')
     MQTT_PORT = int(os.getenv('MQTT_PORT', 1883))
+    MQTT_TLS_CACERTS = os.getenv('MQTT_TLS_CACERTS', None)
+    MQTT_TLS_INSECURE = os.getenv('MQTT_TLS_INSECURE', None)
     MQTT_PREFIX = os.getenv('MQTT_PREFIX', 'miscale')
     TIME_INTERVAL = int(os.getenv('TIME_INTERVAL', 30))
     MQTT_DISCOVERY = os.getenv('MQTT_DISCOVERY',True)
@@ -188,6 +200,11 @@ except FileNotFoundError:
     USER3_DOB = os.getenv('USER3_DOB', '1988-01-01') # DOB (in yyyy-mm-dd format)
     sys.stdout.write(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} - Config Loaded...\n")
 
+if MQTT_TLS_CACERTS is None:
+    MQTT_TLS = None
+else:
+    MQTT_TLS = {'ca_certs':MQTT_TLS_CACERTS, 'insecure':MQTT_TLS_INSECURE}
+
 OLD_MEASURE = ''
 
 def discovery():
@@ -201,7 +218,8 @@ def discovery():
                         retain=True,
                         hostname=MQTT_HOST,
                         port=MQTT_PORT,
-                        auth={'username':MQTT_USERNAME, 'password':MQTT_PASSWORD}
+                        auth={'username':MQTT_USERNAME, 'password':MQTT_PASSWORD},
+                        tls=MQTT_TLS
                     )
     sys.stdout.write(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} - Discovery Completed...\n")
 
@@ -303,7 +321,8 @@ class ScanProcessor():
                 retain=True,
                 hostname=MQTT_HOST,
                 port=MQTT_PORT,
-                auth={'username':MQTT_USERNAME, 'password':MQTT_PASSWORD}
+                auth={'username':MQTT_USERNAME, 'password':MQTT_PASSWORD},
+                tls=MQTT_TLS
             )
             sys.stdout.write(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')} - Data Published ...\n")
         except Exception as error:


### PR DESCRIPTION
Added support for TLS connection to the MQTT server. Configuration through 2 settings:

- Verify TLS connection by checking if MQTT server's certificate is signed by one of the CA certificates provided in the path **MQTT_TLS_CACERTS**
- If **MQTT_TLS_INSECURE** is set to **True** server name will not be checked against host name provided in server certificate (caution, as the name suggests this is insecure! only use in non-production environments)